### PR TITLE
Fix two bugs due to typos in compat.py

### DIFF
--- a/compat/compat.py
+++ b/compat/compat.py
@@ -3066,7 +3066,7 @@ def limb_angle(pos_obj, pos_obs):
     limb_ang = c_double()
     nadir_ang = c_double()
 
-    _limb_angle = ((c_double*3)(*pos_obj), (c_double*3)(*pos_obs),
+    _limb_angle ((c_double*3)(*pos_obj), (c_double*3)(*pos_obs),
                    byref(limb_ang), byref(nadir_ang))
 
     return limb_ang.value, nadir_ang.value


### PR DESCRIPTION
This pair of patches repairs two bugs in `compat.py` that are probably due to typos.

Here, in `cal_date`, the local variable `day` shadows the input argument of the same name:

```
def cal_date(day):
    ...
    year = c_short()
    month = c_short()
    day = c_short()
    hour = c_double()
    ...
    _cal_date(day, byref(year), byref(month), byref(day), byref(hour))

    return year.value, month.value, day.value, hour.value
```

This is fixed in the first patch by renaming the input argument to `jd`.

Here, in `limb_angle`, `_limb_angle` is supposed to be called, but the extraneous `=` instead makes the code in parentheses a tuple that is assigned to `_limb_angle`.

```
_limb_angle = ((c_double*3)(*pos_obj), (c_double*3)(*pos_obs),
               byref(limb_ang), byref(nadir_ang))

return limb_ang.value, nadir_ang.value
```

This is fixed in the second patch by removing the `=`.

I maintain a [MacPorts package of python-novas](http://www.macports.org/ports.php?by=name&substr=novas_py), and these patches are [currently part of that package](https://trac.macports.org/browser/trunk/dports/python/py-novas_py/files/patch-compat.py.diff).
