### PR TITLE
Fix trivial crashing typo.

### DIFF
--- a/compat/compat.py
+++ b/compat/compat.py
@@ -2715,7 +2715,7 @@ def cio_location(jd_tdb, accuracy=0):
     _cio_location.restype = c_short
 
     ra_cio = c_double()
-    ref_sys - c_short()
+    ref_sys = c_short()
 
     return_value = _cio_location(jd_tdb, accuracy, byref(ra_cio),
                                  byref(ref_sys))


### PR DESCRIPTION
With this trivial patch the `cio_location` function doesn't crash, issue #8 :

```
>>> novas.compat.cio_ra(novas.constants.T0)
-0.0002364026890089987
>>> novas.compat.cio_location(novas.constants.T0)
(-0.00023640268900899865, 2)
```
